### PR TITLE
Offboard config

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -178,6 +178,13 @@ const compileCapitalization = (game) => {
   return game.info.capitalization;
 };
 
+const compileMustSellInBlocks = (game) => {
+  if (!game.info.mustSellInBlocks) {
+    return false;
+  }
+  return game.info.mustSellInBlocks;
+};
+
 const compilePrivates = (game) => {
   return map(
     (p) => ({
@@ -396,6 +403,7 @@ const compileGame = (game, opts) => {
     startingCash: compileStartingCash(game),
     capitalization: compileCapitalization(game),
     layout: layout,
+    mustSellInBlocks: compileMustSellInBlocks(game),
     locationNames: compileLocationNames(game, opts),
     tiles: compileTiles(game, isFlat),
     market: compileMarket(game),

--- a/src/game.js
+++ b/src/game.js
@@ -161,6 +161,16 @@ const compileCurrency = (game) => {
   return game.info.currency.replace(/\#/, "%d");
 };
 
+const compileLayout = (game) => {
+  if (game.info.orientation === "horizontal") {
+    return "flat";
+  } else if (game.info.orientation === "vertical") {
+    return "pointy";
+  } else {
+    return "pointy";
+  }
+};
+
 const compilePrivates = (game) => {
   return map(
     (p) => ({
@@ -374,6 +384,7 @@ const compileGame = (game, opts) => {
     bankCash: compileBank(game),
     certLimit: compileCertLimit(game),
     startingCash: compileStartingCash(game),
+    layout: compileLayout(game),
     locationNames: compileLocationNames(game, opts),
     tiles: compileTiles(game),
     market: compileMarket(game),

--- a/src/game.js
+++ b/src/game.js
@@ -107,7 +107,7 @@ const compileLocationNames = (game, opts) => {
   );
 };
 
-const compileTiles = (game) => {
+const compileTiles = (game, isFlat) => {
   return reduce(
     (tiles, id) => {
       if (makerTiles[id] && makerTiles[id].broken) {
@@ -131,7 +131,7 @@ const compileTiles = (game) => {
                 : tile.quantity
               : 1,
             color: tile.color,
-            code: compileHex(tile),
+            code: compileHex(tile, isFlat),
           };
         } else {
           // Just quantity
@@ -336,12 +336,12 @@ const compilePhases = (game) => {
   );
 };
 
-const compileHexes = (game, opts) => {
+const compileHexes = (game, isFlat, opts) => {
   let compiled = {};
 
   getMapHexes(game, opts.map).forEach((hex) => {
     let color = compileColor(hex);
-    let encoding = compileHex(hex);
+    let encoding = compileHex(hex, isFlat);
     let locations = hex.hexes;
 
     if (!compiled[color]) {
@@ -377,6 +377,9 @@ const compileGame = (game, opts) => {
   const filename = compileFileName(game.info.title);
   const modulename = compileModuleName(game.info.title);
 
+  const layout = compileLayout(game);
+  const isFlat = layout === "flat";
+
   return {
     filename,
     modulename,
@@ -384,14 +387,14 @@ const compileGame = (game, opts) => {
     bankCash: compileBank(game),
     certLimit: compileCertLimit(game),
     startingCash: compileStartingCash(game),
-    layout: compileLayout(game),
+    layout: layout,
     locationNames: compileLocationNames(game, opts),
-    tiles: compileTiles(game),
+    tiles: compileTiles(game, isFlat),
     market: compileMarket(game),
     companies: compilePrivates(game),
     corporations: compileCompanies(game, filename, opts),
     trains: compileTrains(game),
-    hexes: compileHexes(game, opts),
+    hexes: compileHexes(game, isFlat, opts),
     phases: compilePhases(game),
   };
 };

--- a/src/game.js
+++ b/src/game.js
@@ -84,6 +84,7 @@ const findName = (hex) => {
     ...(hex.centerTowns || []),
     ...(hex.towns || []),
     ...(hex.offBoardRevenue ? [hex.offBoardRevenue] : []),
+    ...map((n) => ({ name: n }), hex.names || []),
   ];
   let names = chain((p) => (p.name ? [p.name.name] : []), possibles);
   return names.join(" & ");

--- a/src/game.js
+++ b/src/game.js
@@ -83,7 +83,9 @@ const findName = (hex) => {
     ...(hex.cities || []),
     ...(hex.centerTowns || []),
     ...(hex.towns || []),
-    ...(hex.offBoardRevenue ? [hex.offBoardRevenue] : []),
+    ...(hex.offBoardRevenue && !hex.offBoardRevenue.hidden
+      ? [hex.offBoardRevenue]
+      : []),
     ...map((n) => ({ name: n }), hex.names || []),
   ];
   let names = chain((p) => (p.name ? [p.name.name] : []), possibles);

--- a/src/game.js
+++ b/src/game.js
@@ -171,6 +171,13 @@ const compileLayout = (game) => {
   }
 };
 
+const compileCapitalization = (game) => {
+  if (!game.info.capitalization) {
+    return "full";
+  }
+  return game.info.capitalization;
+};
+
 const compilePrivates = (game) => {
   return map(
     (p) => ({
@@ -387,6 +394,7 @@ const compileGame = (game, opts) => {
     bankCash: compileBank(game),
     certLimit: compileCertLimit(game),
     startingCash: compileStartingCash(game),
+    capitalization: compileCapitalization(game),
     layout: layout,
     locationNames: compileLocationNames(game, opts),
     tiles: compileTiles(game, isFlat),

--- a/src/hex.js
+++ b/src/hex.js
@@ -89,7 +89,9 @@ const compileOffboard = (hex) => {
     return `${r.color}_${r.value || r.revenue || r.cost || 0}`;
   }, hex.offBoardRevenue.revenues);
 
-  return [`o=r:${colors.join("|")}`];
+  const hidden = hex.offBoardRevenue.hidden ? ",h:1" : "";
+
+  return [`o=r:${colors.join("|")}${hidden}`];
 };
 
 const compileLabels = (hex) => {
@@ -191,6 +193,15 @@ const compileColor = (hex) => {
   }
 };
 
+const compileRemoveBorders = (hex, isFlat) => {
+  if (!hex.removeBorders) {
+    return [];
+  }
+  const border = (hex.removeBorders[0] + (isFlat ? 1 : 0)) % 6;
+
+  return [`b=e:${border}`];
+};
+
 const compileHex = (hex, isFlat) => {
   if (hex.encoding) {
     return hex.encoding;
@@ -203,6 +214,7 @@ const compileHex = (hex, isFlat) => {
     ...compileTrack(hex, isFlat),
     ...compileLabels(hex),
     ...compileTerrain(hex),
+    ...compileRemoveBorders(hex, isFlat),
   ];
 
   let result = all.join(";");

--- a/src/hex.js
+++ b/src/hex.js
@@ -197,7 +197,7 @@ const compileRemoveBorders = (hex, isFlat) => {
   if (!hex.removeBorders) {
     return [];
   }
-  const border = (hex.removeBorders[0] + (isFlat ? 1 : 0)) % 6;
+  const border = (hex.removeBorders[0] - (isFlat ? 1 : 0)) % 6;
 
   return [`b=e:${border}`];
 };

--- a/src/hex.js
+++ b/src/hex.js
@@ -40,11 +40,17 @@ const compileTowns = (hex) => {
     }
 
     let town = `t=r:${revenue}`;
-    if (t.group) {
-      town += `,g:${t.group}`;
-    }
+    town += compileGroups(t.groups);
+
     return town;
   }, concat(hex.centerTowns || [], hex.towns || []));
+};
+
+const compileGroups = (groups) => {
+  if (!groups) {
+    return "";
+  }
+  return `,g:${groups.join("|")}`;
 };
 
 const compileMultiRevenue = (offboardRevenue) => {
@@ -82,9 +88,7 @@ const compileCities = (hex) => {
     if (c.size > 1) {
       city += `,s:${c.size}`;
     }
-    if (c.group) {
-      city += `,g:${c.group}`;
-    }
+    city += compileGroups(c.groups);
     return city;
   }, hex.cities);
 };
@@ -121,8 +125,7 @@ const compileOffboard = (hex) => {
 
   const revenue = compileMultiRevenue(hex.offBoardRevenue);
 
-  const group = hex.offBoardRevenue.group;
-  const g = group ? `,g:${group}` : "";
+  const g = compileGroups(hex.offBoardRevenue.groups);
 
   return [`o=r:${revenue}${g}`];
 };

--- a/src/hex.js
+++ b/src/hex.js
@@ -32,7 +32,11 @@ const compileTowns = (hex) => {
   let values = getValues(hex);
 
   return addIndex(map)((t, i) => {
-    return "t=r:" + (values[i] || values[0] || 0);
+    let town = "t=r:" + (values[i] || values[0] || 0);
+    if (t.group) {
+      town += `,g:${t.group}`;
+    }
+    return town;
   }, concat(hex.centerTowns || [], hex.towns || []));
 };
 
@@ -47,6 +51,9 @@ const compileCities = (hex) => {
     let city = "c=r:" + (values[i] || values[0] || 0);
     if (c.size > 1) {
       city += `,s:${c.size}`;
+    }
+    if (c.group) {
+      city += `,g:${c.group}`;
     }
     return city;
   }, hex.cities);
@@ -91,7 +98,10 @@ const compileOffboard = (hex) => {
 
   const hidden = hex.offBoardRevenue.hidden ? ",h:1" : "";
 
-  return [`o=r:${colors.join("|")}${hidden}`];
+  const group = hex.offBoardRevenue.group;
+  const g = group ? `,g:${group}` : "";
+
+  return [`o=r:${colors.join("|")}${g}${hidden}`];
 };
 
 const compileLabels = (hex) => {

--- a/src/hex.js
+++ b/src/hex.js
@@ -140,10 +140,10 @@ const compileTrackGauge = (gauge) => {
   }
 };
 
-const compileTrackSides = (t, r) => {
+const compileTrackSides = (t, r, isFlat) => {
   // Check if we have a revenue center to deal with
   const hasRevenue = !isNaN(r);
-  const side = t.side || 1;
+  const side = (t.side || 1) + (isFlat ? 0 : 1);
 
   // Now switch on type
   switch (t.type) {
@@ -158,7 +158,7 @@ const compileTrackSides = (t, r) => {
   }
 };
 
-const compileTrack = (hex) => {
+const compileTrack = (hex, isFlat) => {
   if (!hex.track) {
     return [];
   }
@@ -170,7 +170,7 @@ const compileTrack = (hex) => {
     // Simple for now, just let every track cycle
     // between revenue locations
     let revenue = i % numRevenue;
-    let sides = compileTrackSides(t, revenue);
+    let sides = compileTrackSides(t, revenue, isFlat);
 
     return map((s) => {
       return `p=${s}${compileTrackGauge(t.gauge)}`;
@@ -191,7 +191,7 @@ const compileColor = (hex) => {
   }
 };
 
-const compileHex = (hex) => {
+const compileHex = (hex, isFlat) => {
   if (hex.encoding) {
     return hex.encoding;
   }
@@ -200,7 +200,7 @@ const compileHex = (hex) => {
     ...compileOffboard(hex),
     ...compileCities(hex),
     ...compileTowns(hex),
-    ...compileTrack(hex),
+    ...compileTrack(hex, isFlat),
     ...compileLabels(hex),
     ...compileTerrain(hex),
   ];


### PR DESCRIPTION
Related:
* https://github.com/tobymao/18xx/pull/642
* https://github.com/18xx-maker/games/pull/29
* https://github.com/18xx-maker/schemas/pull/8

https://imgur.com/a/9JWnf15

Changes:

* enable hiding of offboard revenues
* enable hiding of borders
* fix hiding of location names when `names` key is used, as in 1846 F20/Homewood
* add some top-level keys
    * layout (flat/pointy, default pointy)
    * capitilization (full/incremental, default full)
    * mustSellInBlocks (bool, default false)
* adjust track numbers as needed for pointy layout (pass `isFlat` argument around)
* fix rendering track / exporting offboards for hexes with cities/towns that have variable revenue but also have track to a normal revenue center (e.g., Toronto in 1817 or Pittsburgh in 18Chesapeake)
* add groups to cities/towns/offboards

