### PR TITLE
18xxgames tile language - use more descriptive strings instead of single characters

### DIFF
--- a/src/hex.js
+++ b/src/hex.js
@@ -4,6 +4,8 @@ const concat = require("ramda/src/concat");
 const map = require("ramda/src/map");
 const chain = require("ramda/src/chain");
 const find = require("ramda/src/find");
+const any = require("ramda/src/any");
+const has = require("ramda/src/has");
 
 const terrainMapping = {
   river: "water",
@@ -160,7 +162,7 @@ const ab = (a, b) => {
 
 const aj = (a) => {
   a = (a - 1) % 6;
-  return [`a:${a},b:junction`];
+  return [`a:${a},b:_0`];
 };
 
 const compileTrackGauge = (gauge) => {
@@ -230,12 +232,29 @@ const compileRemoveBorders = (hex, isFlat) => {
   return [`border=edge:${edge}`];
 };
 
+const compileJunction = (hex) => {
+  if (!hex.track) {
+    return [];
+  }
+
+  if (hex.cities || hex.towns || hex.centerTowns || hex.offBoardRevenue) {
+    return [];
+  }
+
+  if (any(has("type"), hex.track)) {
+    return [];
+  }
+
+  return ["junction"];
+};
+
 const compileHex = (hex, isFlat) => {
   if (hex.encoding) {
     return hex.encoding;
   }
 
   let all = [
+    ...compileJunction(hex),
     ...compileOffboard(hex),
     ...compileCities(hex),
     ...compileTowns(hex),

--- a/src/hex.js
+++ b/src/hex.js
@@ -114,7 +114,7 @@ const compileTerrain = (hex) => {
   }
 
   if (types.length > 0) {
-    result.push(`terrain:${types.join("+")}`);
+    result.push(`terrain:${types.join("|")}`);
   }
 
   return [result.join(",")];

--- a/src/hex.js
+++ b/src/hex.js
@@ -39,7 +39,7 @@ const compileTowns = (hex) => {
       revenue = values[i] || values[0] || 0;
     }
 
-    let town = `t=r:${revenue}`;
+    let town = `town=revenue:${revenue}`;
     town += compileGroups(t.groups);
 
     return town;
@@ -50,7 +50,7 @@ const compileGroups = (groups) => {
   if (!groups) {
     return "";
   }
-  return `,g:${groups.join("|")}`;
+  return `,groups:${groups.join("|")}`;
 };
 
 const compileMultiRevenue = (offboardRevenue) => {
@@ -63,7 +63,7 @@ const compileMultiRevenue = (offboardRevenue) => {
 
   let multiRevenue = colors.join("|");
   if (offboardRevenue.hidden) {
-    multiRevenue += ",h:1";
+    multiRevenue += ",hide:1";
   }
 
   return multiRevenue;
@@ -84,9 +84,9 @@ const compileCities = (hex) => {
       revenue = values[i] || values[0] || 0;
     }
 
-    let city = `c=r:${revenue}`;
+    let city = `city=revenue:${revenue}`;
     if (c.size > 1) {
-      city += `,s:${c.size}`;
+      city += `,slots:${c.size}`;
     }
     city += compileGroups(c.groups);
     return city;
@@ -108,11 +108,11 @@ const compileTerrain = (hex) => {
   let result = [];
   let cost = find((t) => t.cost, hex.terrain);
   if (cost) {
-    result.push(`u=c:${cost.cost}`);
+    result.push(`upgrade=cost:${cost.cost}`);
   }
 
   if (types.length > 0) {
-    result.push(`t:${types.join("+")}`);
+    result.push(`terrain:${types.join("+")}`);
   }
 
   return [result.join(",")];
@@ -127,7 +127,7 @@ const compileOffboard = (hex) => {
 
   const g = compileGroups(hex.offBoardRevenue.groups);
 
-  return [`o=r:${revenue}${g}`];
+  return [`offboard=revenue:${revenue}${g}`];
 };
 
 const compileLabels = (hex) => {
@@ -136,7 +136,7 @@ const compileLabels = (hex) => {
   }
 
   return map((l) => {
-    return `l=${l.label}`;
+    return `label=${l.label}`;
   }, hex.labels);
 };
 
@@ -160,22 +160,14 @@ const ab = (a, b) => {
 
 const aj = (a) => {
   a = (a - 1) % 6;
-  return [`a:${a},b:j`];
+  return [`a:${a},b:junction`];
 };
 
 const compileTrackGauge = (gauge) => {
-  switch (gauge) {
-    case "narrow":
-      return ",t:n";
-    case "dual":
-      return ",t:d";
-    case "line":
-      return ",t:l";
-    case "dashed":
-      return ",t:-";
-    default:
-      return "";
+  if (!gauge) {
+    return "";
   }
+  return `,track:${gauge}`;
 };
 
 const compileTrackSides = (t, r, isFlat) => {
@@ -211,7 +203,7 @@ const compileTrack = (hex, isFlat) => {
     let sides = compileTrackSides(t, revenue, isFlat);
 
     return map((s) => {
-      return `p=${s}${compileTrackGauge(t.gauge)}`;
+      return `path=${s}${compileTrackGauge(t.gauge)}`;
     }, sides);
   }, hex.track);
 };
@@ -233,9 +225,9 @@ const compileRemoveBorders = (hex, isFlat) => {
   if (!hex.removeBorders) {
     return [];
   }
-  const border = (hex.removeBorders[0] - (isFlat ? 1 : 0)) % 6;
+  const edge = (hex.removeBorders[0] - (isFlat ? 1 : 0)) % 6;
 
-  return [`b=e:${border}`];
+  return [`border=edge:${edge}`];
 };
 
 const compileHex = (hex, isFlat) => {
@@ -254,17 +246,6 @@ const compileHex = (hex, isFlat) => {
   ];
 
   let result = all.join(";");
-
-  switch (result) {
-    case "":
-      return "blank";
-    case "c=r:0":
-      return "city";
-    case "t=r:0":
-      return "town";
-    default:
-      return result;
-  }
 
   return result;
 };

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -24,7 +24,7 @@ const compileTiles = (tiles) => {
 
     colors[color][id] = {
       id,
-      encoding: hex.compileHex(tile),
+      encoding: hex.compileHex(tile, true),
       broken: tile.broken,
     };
   }, tiles);

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -13,27 +13,6 @@ const toModule = (name) =>
 
 // Create the json structure needed for our tiles template
 const compileTiles = (tiles) => {
-  let data = [
-    {
-      name: "white",
-      module: "WHITE",
-      tiles: [
-        {
-          id: "blank",
-          encoding: "",
-        },
-        {
-          id: "town",
-          encoding: "t=r:0",
-        },
-        {
-          id: "city",
-          encoding: "c=r:0",
-        },
-      ],
-    },
-  ];
-
   let colors = {};
 
   forEachObjIndexed((tile, id) => {

--- a/templates/tiles.hbs
+++ b/templates/tiles.hbs
@@ -9,11 +9,11 @@ module Engine
     module Tile
       WHITE = {
         'blank' => '',
-        'town' => 't=r:0',
-        'city' => 'c=r:0',
+        'city' => 'city=revenue:0',
+        'town' => 'town=revenue:0',
       }.freeze
 
-      # Red tiles don't exist yet
+      BLUE = {}.freeze
       RED = {}.freeze
 
       {{#each colors}}


### PR DESCRIPTION
Also change how junctions are handled, and separate multiple terrain types with `|` instead of `+`

See https://github.com/tobymao/18xx/pull/651 and https://github.com/tobymao/18xx/pull/657